### PR TITLE
Bootstrap v4+ compatibility

### DIFF
--- a/examples/Utils.elm
+++ b/examples/Utils.elm
@@ -47,7 +47,7 @@ debuggingView data =
 bootstrap : Html msg
 bootstrap =
     node "link"
-        [ href "https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
+        [ href "https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"
         , rel "stylesheet"
         ]
         []

--- a/src/Dialog.elm
+++ b/src/Dialog.elm
@@ -75,7 +75,7 @@ view maybeConfig =
             [ div
                 ([ classList
                     [ ( "modal", True )
-                    , ( "in", displayed )
+                    , ( "show", displayed )
                     ]
                  , style
                     [ ( "display"
@@ -136,7 +136,7 @@ wrapFooter footer =
 
 backdrop : Maybe (Config msg) -> Html msg
 backdrop config =
-    div [ classList [ ( "modal-backdrop in", isJust config ) ] ]
+    div [ classList [ ( "modal-backdrop show", isJust config ) ] ]
         []
 
 


### PR DESCRIPTION
2 changes:

1. Use `show` instead of `in` class when modal is active (See https://github.com/twbs/bootstrap/blob/v4-dev/scss/_modal.scss#L88)
2. Pull in latest bootstrap stylesheet in examples folder