### PR TITLE
Readme: Absolute path used for screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Elm modal dialog boxes that fits in neatly with the Elm architecture.
 ## Examples
 
 
-![Screenshot](screenshot.png?raw=true)
+![Screenshot](https://raw.githubusercontent.com/krisajenkins/elm-dialog/master/screenshot.png)
 
 See the `examples/` directory for two fully-worked examples:
 


### PR DESCRIPTION
This way the screenshot image is shown correctly on github and package.elm-lang.org

![image](https://user-images.githubusercontent.com/13085980/47161368-305b2b80-d2f2-11e8-840d-e7839ebb066f.png)
